### PR TITLE
Fix bugs and use the formatter in the widgets

### DIFF
--- a/src/barchart/model.tsx
+++ b/src/barchart/model.tsx
@@ -1,5 +1,5 @@
 import { createRoot, Root } from 'react-dom/client';
-import type { TConditionNode, ApiRequestor, IWidget, WidgetArgs, ApprTab } from 'pa-typings';
+import type { TConditionNode, ApiRequestor, IWidget, WidgetArgs, ApprTab, ExternalWidgetFormatter } from 'pa-typings';
 
 import { BarChartView } from './view';
 import * as scss from './styles.scss';
@@ -7,11 +7,13 @@ import * as scss from './styles.scss';
 class BarChartWidget implements IWidget {
   private requestor: ApiRequestor | null = null;
   private root: Root | null = null;
-  private condition: TConditionNode | undefined = undefined;
+  private condition?: TConditionNode;
+  private formatter?: ExternalWidgetFormatter;
 
   constructor(private args: WidgetArgs) {}
 
-  updateData(requestor: ApiRequestor): void {
+  async updateData(requestor: ApiRequestor) {
+    this.formatter = await this.args.getFormatter();
     this.requestor = requestor;
     this.updateContainer();
   }
@@ -39,8 +41,9 @@ class BarChartWidget implements IWidget {
   }
 
   private updateContainer() {
-    if (this.root && this.requestor)
+    if (this.root && this.requestor && this.formatter)
       this.root.render(<BarChartView
+        formatter={this.formatter}
         setCondition={this.setCondition}
         requestor={this.requestor}
         args={this.args}

--- a/src/barchart/view.tsx
+++ b/src/barchart/view.tsx
@@ -9,13 +9,12 @@ import {
   ResponsiveContainer,
   Cell
 } from 'recharts';
-import type { TConditionNode, ApiRequestor, WidgetArgs } from 'pa-typings';
+import type { TConditionNode, ApiRequestor, WidgetArgs, ExternalWidgetFormatter } from 'pa-typings';
 import { Select, type Column } from 'Select';
-
-import { variantToDate } from 'helper';
 
 interface Props {
   requestor: ApiRequestor;
+  formatter: ExternalWidgetFormatter;
   args?: WidgetArgs;
   condition?: TConditionNode;
   setCondition: (cond: TConditionNode) => void;
@@ -28,7 +27,7 @@ type DataType = {
   color: string;
 };
 
-export const BarChartView: React.FC<Props> = ({ requestor, args, setCondition }) => {
+export const BarChartView: React.FC<Props> = ({ requestor, args, formatter, setCondition }) => {
   const [data, setData] = React.useState<DataType[]>([]);
   const [columns, setColumns] = React.useState<Column[]>([]);
   const [colId, setColId] = React.useState(-1);
@@ -75,8 +74,9 @@ export const BarChartView: React.FC<Props> = ({ requestor, args, setCondition })
       setData(values.rowIDs.map((idx) => {
         let tableValue = values.table?.[+idx]?.[0] ?? 'missing';
         let value = tableValue;
+        const column = columns[colId];
         if (columns[colId].type == 'DateTime')
-          tableValue = variantToDate(+tableValue).toLocaleDateString('ru-RU');
+          tableValue = formatter.formatValue(column.name, +tableValue);
         if (columns[colId].type == 'String')
           value = values.textIDs?.[0]?.[idx] ?? value;
         const total = Number(values.table?.[+idx][1]);

--- a/src/calendar/model.tsx
+++ b/src/calendar/model.tsx
@@ -1,16 +1,18 @@
 import { createRoot, Root } from 'react-dom/client';
-import type { TConditionNode, ApiRequestor, IWidget, WidgetArgs, ApprTab } from 'pa-typings';
+import type { TConditionNode, ApiRequestor, IWidget, WidgetArgs, ApprTab, ExternalWidgetFormatter } from 'pa-typings';
 
 import { Calendar } from './view';
 
 class CalendarWidget implements IWidget {
   private requestor: ApiRequestor | null = null;
   private root: Root | null = null;
-  private condition: TConditionNode | undefined = undefined;
+  private condition?: TConditionNode;
+  private formatter?: ExternalWidgetFormatter;
 
   constructor(private args: WidgetArgs) {}
 
-  updateData(requestor: ApiRequestor): void {
+  async updateData(requestor: ApiRequestor) {
+    this.formatter = await this.args.getFormatter();
     this.requestor = requestor;
     this.updateContainer();
   }
@@ -35,8 +37,9 @@ class CalendarWidget implements IWidget {
   }
 
   private updateContainer() {
-    if (this.root && this.requestor)
+    if (this.root && this.requestor && this.formatter)
       this.root.render(<Calendar
+        formatter={this.formatter}
         setCondition={this.setCondition}
         condition={this.condition}
         requestor={this.requestor}

--- a/src/calendar/view.tsx
+++ b/src/calendar/view.tsx
@@ -54,10 +54,17 @@ export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condi
     fetchData();
   }, [requestor]);
 
-  const filter = (action: number, columnId: number, day: number, month: number, year: number, wrapperGuid: string) => {
+  const filter = (
+    action: number,
+    column: ColumnInfo,
+    day: number,
+    month: number,
+    year: number,
+    wrapperGuid: string
+  ) => {
     return requestor.filter({
       action,
-      columnId,
+      columnId: column.id,
       day,
       delta: 0,
       howsearch: 0,
@@ -69,8 +76,8 @@ export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condi
       value: 0,
       wrapperGuid,
       year,
-      columnName: '',
-      columnType: ''
+      columnName: column.title,
+      columnType: column.type
     });
   };
 
@@ -85,14 +92,14 @@ export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condi
       if (column == undefined)
         return;
 
-      const filterOnFirstToInf = await filter(5, column.id, 1, date.getMonth() + 1, date.getFullYear(), wrapperGuid);
+      const filterOnFirstToInf = await filter(5, column, 1, date.getMonth() + 1, date.getFullYear(), wrapperGuid);
 
       const day = new Date(date.getFullYear(), date.getMonth(), 0).getDate();
       const year = date.getMonth() >= 11 ? date.getFullYear() + 1 : date.getFullYear();
       const month = date.getMonth() >= 11 ? 1 : date.getMonth() + 2;
       const filterOnLastToFirst = await filter(
         3,
-        column.id,
+        column,
         day,
         month,
         year,

--- a/src/calendar/view.tsx
+++ b/src/calendar/view.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react';
-import type { TConditionNode, ApiRequestor, Table, ColumnInfo, WidgetArgs } from 'pa-typings';
+import type { TConditionNode, ApiRequestor, Table, ColumnInfo, WidgetArgs, ExternalWidgetFormatter } from 'pa-typings';
 import { Group, MantineProvider } from '@mantine/core';
 import { DatePicker, DayProps } from '@mantine/dates';
-import { dateToVariant, variantToDate } from 'helper';
+
+const BASE_DATE: Record<string, number> = {
+  'pa6': 25569.0,
+  'pagrid': 0
+};
 
 interface Props {
   requestor: ApiRequestor;
+  formatter: ExternalWidgetFormatter;
   args?: WidgetArgs;
   condition?: TConditionNode;
   setCondition: (cond: TConditionNode) => void;
 }
 
-export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condition }) => {
+export const Calendar: React.FC<Props> = ({ requestor, formatter, args, setCondition, condition }) => {
   const wrapperGuidRef = React.useRef<{ wrapperGuid: string }>({ wrapperGuid: '' });
   const [map, setMap] = React.useState<Map<number, number>>(new Map());
   const [date, setDate] = React.useState<Date>(new Date());
@@ -40,7 +45,8 @@ export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condi
       if (!columns.length)
         return;
 
-      setColumn(columns[0]);
+      const column = columns[0];
+      setColumn(column);
       const values = await requestor.values({
         columnIndexes: columns.map(c => c.id),
         offset: 0,
@@ -48,7 +54,7 @@ export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condi
         wrapperGuid: guid.wrapperGuid
       });
       const startDate = Array.from(getData(values), ([v, _]) => v)[0];
-      const date = variantToDate(startDate);
+      const date = new Date(formatter.formatValue(column.title, startDate));
       setDate(date);
     };
     fetchData();
@@ -128,12 +134,13 @@ export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condi
     if (!date || !column)
       return;
 
-    const value = dateToVariant(date);
+    const value = dateToVariant(date, BASE_DATE[args!.serverType]);
     const condition: TConditionNode = {
       borderCond: 1,
       dVal: value,
       dVal2: value + 1,
-      columnName: column.title
+      columnName: column.title,
+      columnFunc: 'dateonly'
     };
 
     setValue(date);
@@ -142,7 +149,7 @@ export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condi
   };
 
   const getDayProps = (date: Date): Partial<DayProps> => {
-    const data = dateToVariant(date);
+    const data = dateToVariant(date, BASE_DATE[args!.serverType]);
     if (!map.has(data))
       return {};
 
@@ -188,3 +195,7 @@ export const Calendar: React.FC<Props> = ({ requestor, args, setCondition, condi
     </MantineProvider>
   );
 };
+
+export function dateToVariant(date: Date, baseDate: number) {
+  return baseDate + ((date.getTime() - (date.getTimezoneOffset() * 60 * 1000)) / (1000 * 60 * 60 * 24));
+}

--- a/src/formcalendar/view.tsx
+++ b/src/formcalendar/view.tsx
@@ -3,8 +3,6 @@ import type { FormValue, FormValueBasic } from 'pa-typings';
 import { Group, MantineProvider } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 
-import { dateToVariant, variantToDate } from 'helper';
-
 interface Props {
   getValue(): FormValue;
   setValue(val: FormValueBasic[]): Promise<void> | void;

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -20,15 +20,3 @@ export function joinAnd(conditions: TConditionNode[]): TConditionNode {
 export function joinOr(conditions: TConditionNode[]): TConditionNode {
   return joinConditions(TColumnOperation.co_OR, conditions);
 }
-
-const BASE_DATE = Date.UTC(1899, 11, 30);
-const S_PER_DAY = 24 * 3600;
-const MS_PER_DAY = S_PER_DAY * 1000;
-export function variantToDate(daysAfterBaseDate: number, dateOnly?: boolean): Date {
-  const ms = dateOnly ? MS_PER_DAY * Math.trunc(daysAfterBaseDate) : Math.round(MS_PER_DAY * daysAfterBaseDate);
-  return new Date(BASE_DATE + ms);
-}
-
-export function dateToVariant(date: Date) {
-  return 25569.0 + ((date.getTime() - (date.getTimezoneOffset() * 60 * 1000)) / (1000 * 60 * 60 * 24));
-}

--- a/src/table/model.tsx
+++ b/src/table/model.tsx
@@ -1,5 +1,5 @@
 import { createRoot, Root } from 'react-dom/client';
-import type { TConditionNode, ApiRequestor, IWidget, WidgetArgs, ApprTab } from 'pa-typings';
+import type { TConditionNode, ApiRequestor, IWidget, WidgetArgs, ApprTab, ExternalWidgetFormatter } from 'pa-typings';
 
 import { SimpleTable } from './view';
 import * as styles from './styles.scss';
@@ -7,11 +7,13 @@ import * as styles from './styles.scss';
 class TableWidget implements IWidget {
   private requestor: ApiRequestor | null = null;
   private root: Root | null = null;
-  private condition: TConditionNode | undefined = undefined;
+  private condition?: TConditionNode;
+  private formatter?: ExternalWidgetFormatter;
 
   constructor(private args: WidgetArgs) {}
 
-  updateData(requestor: ApiRequestor): void {
+  async updateData(requestor: ApiRequestor) {
+    this.formatter = await this.args.getFormatter();
     this.requestor = requestor;
     this.updateContainer();
   }
@@ -40,8 +42,15 @@ class TableWidget implements IWidget {
   }
 
   private updateContainer() {
-    if (this.root)
-      this.root.render(<SimpleTable setCondition={this.setCondition} requestor={this.requestor!} args={this.args} />);
+    if (this.root && this.formatter && this.requestor)
+      this.root.render((
+        <SimpleTable
+          formatter={this.formatter}
+          setCondition={this.setCondition}
+          requestor={this.requestor}
+          args={this.args}
+        />
+      ));
   }
 
   getApprSchema(): ApprTab[] | undefined {

--- a/src/table/view.tsx
+++ b/src/table/view.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { TConditionNode, ApiRequestor, ColumnInfo, WidgetArgs } from 'pa-typings';
+import type { TConditionNode, ApiRequestor, ColumnInfo, WidgetArgs, ExternalWidgetFormatter } from 'pa-typings';
 
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -10,15 +10,16 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { TablePagination } from '@mui/material';
 
-import { joinAnd, joinOr, variantToDate } from 'helper';
+import { joinAnd, joinOr } from 'helper';
 
 interface Props {
   requestor: ApiRequestor;
+  formatter: ExternalWidgetFormatter;
   args?: WidgetArgs;
   setCondition: (cond: TConditionNode) => void;
 }
 
-export const SimpleTable: React.FC<Props> = ({ requestor, args, setCondition }) => {
+export const SimpleTable: React.FC<Props> = ({ requestor, args, formatter, setCondition }) => {
   const [columns, setColumns] = React.useState<ColumnInfo[]>([]);
   const [rows, setRows] = React.useState<any>([]);
   const [page, setPage] = React.useState(0);
@@ -50,16 +51,16 @@ export const SimpleTable: React.FC<Props> = ({ requestor, args, setCondition }) 
         rowCount
       });
       const rows = values.table;
-      const dateTimeIds = [];
+      const dateTimeColumns = new Map<string, ColumnInfo>();
       for (const col of columns) {
         if (col.type === 'DateTime') {
-          dateTimeIds.push(col.id);
+          dateTimeColumns.set(col.title, col);
         }
       }
 
-      if (dateTimeIds.length && rows?.length) {
+      if (dateTimeColumns.size && rows?.length) {
         for (const r of rows) {
-          dateTimeIds.forEach(id => r[id] = variantToDate(+r[id]).toLocaleDateString());
+          dateTimeColumns.forEach(col => r[col.id] = formatter.formatValue(col.title, r[col.id]));
         }
       }
 


### PR DESCRIPTION
1. Fix the "Error: Neither column nor variable "" was found)" error un the pagrid.
<img width="962" height="635" alt="image" src="https://github.com/user-attachments/assets/9fe56e65-af52-4efd-983c-d64b236f3a0f" />


2. Fix: incorrect date display in pagrid — use formatter

2.1. Calendar
Before:
<img width="427" height="379" alt="image" src="https://github.com/user-attachments/assets/19e9a4d7-c3e1-4d9a-9f8b-1454c1610f74" />

After:
<img width="409" height="319" alt="image" src="https://github.com/user-attachments/assets/33db6ce7-a273-49d0-af6c-d9f87426f14d" />

2.2. Table
Before:
<img width="416" height="449" alt="image" src="https://github.com/user-attachments/assets/0a572e2a-5f37-4572-a1b3-761475c592b8" />

After:
<img width="389" height="415" alt="image" src="https://github.com/user-attachments/assets/b32bb691-9d7f-4a54-bc55-58042108b7c4" />

2.3. Bar chart
Before:
<img width="437" height="428" alt="image" src="https://github.com/user-attachments/assets/596ca1c3-a60f-42d9-9b70-f100b0835bb3" />

After:
<img width="415" height="421" alt="image" src="https://github.com/user-attachments/assets/fb169acc-d0e4-4774-9ffb-e51594ba93a7" />
